### PR TITLE
removed deprecated ongenerate and replace with generateBundle hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function(options={}) {
 
     return {
         name: name,
-        ongenerate: function(object) {
+        generateBundle: function(object) {
 
             for (key in options) {
                 if (key == "verbose") continue;


### PR DESCRIPTION
## Summary
according to : https://rollupjs.org/guide/en#hooks

**ongenerate** hook is deprecated and is replaced with **generateBundle** hook.

## Current behaviour
a deprecation message is displayed in the rollup cli:
```
(!) rollup-plugin-copy plugin: The ongenerate hook used by plugin rollup-plugin-copy is deprecated. The generateBundle hook should be used instead.
```
## Behaviour after change
the deprecation message is removed & process continues with no side effect.