### PR TITLE
skip already copy targets

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -103,6 +103,16 @@ copy({
 })
 ```
 
+### skipRepetition
+
+Will skip the copy with the same (from, to)
+
+```js
+copy({
+  skipRepetition: true
+})
+```
+
 All other options are passed directly to [fs-extra copy function](https://github.com/jprichardson/node-fs-extra/blob/7.0.0/docs/copy.md), which is used inside.
 
 ## Original Author

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ export default function copy(options = {}) {
     targets = [],
     verbose = false,
     warnOnNonExist = false,
+    skipRepetition = false,
     ...rest
   } = options
 
@@ -54,11 +55,14 @@ export default function copy(options = {}) {
 
         await Promise.all(processedTargets.map(async ({ from, to }) => {
           try {
-            // skip already copy targets
-            if (alreadyCopyTargets.find(target => target.from === from && target.to === to)) {
-              return
+            if (skipRepetition) {
+              // skip already copy targets
+              if (alreadyCopyTargets.find(target => target.from === from && target.to === to)) {
+                return
+              }
+              alreadyCopyTargets.push({ from, to })
             }
-            alreadyCopyTargets.push({ from, to })
+
             await fs.copy(from, to, rest)
 
             if (verbose) {

--- a/src/index.js
+++ b/src/index.js
@@ -28,8 +28,12 @@ export default function copy(options = {}) {
     ...rest
   } = options
 
+  let alreadyCopyTargets = []
   return {
     name: 'copy',
+    watchChange() {
+      alreadyCopyTargets = []
+    },
     async generateBundle(outputOptions) {
       let processedTargets = []
 
@@ -50,6 +54,11 @@ export default function copy(options = {}) {
 
         await Promise.all(processedTargets.map(async ({ from, to }) => {
           try {
+            // skip already copy targets
+            if (alreadyCopyTargets.find(target => target.from === from && target.to === to)) {
+              return
+            }
+            alreadyCopyTargets.push({ from, to })
             await fs.copy(from, to, rest)
 
             if (verbose) {


### PR DESCRIPTION
I have multiple output in rollup.config.js， it will copy the files every output。
So I add the skip