### PR TITLE
Watch copied files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ export default function copy(options = {}) {
 
   return {
     name: 'copy',
-    [hook]: async () => {
+    async [hook]() {
       if (copyOnce && copied) {
         return
       }
@@ -88,6 +88,10 @@ export default function copy(options = {}) {
         }
 
         for (const { src, dest } of copyTargets) {
+          try {
+            this.addWatchFile(src)
+          } catch { /* Cannot call addWatchFile after the build has finished. */ } 
+
           await fs.copy(src, dest, restPluginOptions)
 
           if (verbose) {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -228,6 +228,93 @@ describe('Copy', () => {
     expect(await fs.pathExists('dist/scss-multiple/nested-renamed')).toBe(true)
     expect(await fs.pathExists('dist/scss-multiple/nested-renamed/scss-3.scss')).toBe(true)
   })
+
+  test('Watches copied files in pre-build hook', async () => {
+    const watcher = watch({
+      input: 'src/index.js',
+      output: {
+        dir: 'build',
+        format: 'esm'
+      },
+      plugins: [
+        copy({
+          hook: 'buildStart',
+          targets: [
+            { src: 'src/assets/asset-1.js', dest: 'dist' }
+          ]
+        })
+      ]
+    })
+
+    await sleep(1000)
+
+    expect(await fs.pathExists('dist/asset-1.js')).toBe(true)
+
+    await fs.remove('dist')
+
+    expect(await fs.pathExists('dist/asset-1.js')).toBe(false)
+
+    await replace({
+      files: 'src/assets/asset-1.js',
+      from: 'asset1',
+      to: 'assetX'
+    })
+
+    await sleep(1000)
+
+    expect(await fs.pathExists('dist/asset-1.js')).toBe(true)
+
+    watcher.close()
+
+    await replace({
+      files: 'src/assets/asset-1.js',
+      from: 'assetX',
+      to: 'asset1'
+    })
+  })
+
+  test('Does not watch copied files in post-build hook', async () => {
+    const watcher = watch({
+      input: 'src/index.js',
+      output: {
+        dir: 'build',
+        format: 'esm'
+      },
+      plugins: [
+        copy({
+          targets: [
+            { src: 'src/assets/asset-1.js', dest: 'dist' }
+          ]
+        })
+      ]
+    })
+
+    await sleep(1000)
+
+    expect(await fs.pathExists('dist/asset-1.js')).toBe(true)
+
+    await fs.remove('dist')
+
+    expect(await fs.pathExists('dist/asset-1.js')).toBe(false)
+
+    await replace({
+      files: 'src/assets/asset-1.js',
+      from: 'asset1',
+      to: 'assetX'
+    })
+
+    await sleep(1000)
+
+    expect(await fs.pathExists('dist/asset-1.js')).toBe(false)
+
+    watcher.close()
+
+    await replace({
+      files: 'src/assets/asset-1.js',
+      from: 'assetX',
+      to: 'asset1'
+    })
+  })
 })
 
 describe('Options', () => {


### PR DESCRIPTION
Re: #5 (Support rollup's watch mode)

This adds all files that are copied directly to Rollup's watch list.

