### PR TITLE
Add transform feature (enabled only on files)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,19 @@ copy({
 })
 ```
 
+#### transfrom
+
+Type: `buffer => buffer | string | Uint8Array` | Default: `undefined`
+
+Pass a function to transform the files content before beign copied by the plugin. It does not change the source files contents, only the destination ones.
+
+```js
+copy({
+  targets: [{ src: 'assets/*', dest: 'dist/public' }],
+  hook: 'writeBundle'
+})
+```
+
 #### copyOnce
 
 Type: `boolean` | Default: `false`

--- a/readme.md
+++ b/readme.md
@@ -52,8 +52,9 @@ Array of targets to copy. A target is an object with properties:
 - **src** (`string` `Array`): Path or glob of what to copy
 - **dest** (`string` `Array`): One or more destinations where to copy
 - **rename** (`string` `Function`): Change destination file or folder name
+- **transform** (`Function`): Modify file contents
 
-Each object should have **src** and **dest** properties, **rename** is optional. [globby](https://github.com/sindresorhus/globby) is used inside, check it for [glob pattern](https://github.com/sindresorhus/globby#globbing-patterns) examples.
+Each object should have **src** and **dest** properties, **rename** and **transform** are optional. [globby](https://github.com/sindresorhus/globby) is used inside, check it for [glob pattern](https://github.com/sindresorhus/globby#globbing-patterns) examples.
 
 ##### File
 
@@ -134,6 +135,18 @@ copy({
 })
 ```
 
+##### Transform file contents
+
+```js
+copy({
+  targets: [{
+    src: 'src/index.html',
+    dest: 'dist/public',
+    transform: (contents) => contents.toString().replace('__SCRIPT__', 'app.js')
+  }]
+})
+```
+
 #### verbose
 
 Type: `boolean` | Default: `false`
@@ -152,19 +165,6 @@ copy({
 Type: `string` | Default: `buildEnd`
 
 [Rollup hook](https://rollupjs.org/guide/en/#hooks) the plugin should use. By default, plugin runs when rollup has finished bundling, before bundle is written to disk.
-
-```js
-copy({
-  targets: [{ src: 'assets/*', dest: 'dist/public' }],
-  hook: 'writeBundle'
-})
-```
-
-#### transfrom
-
-Type: `buffer => buffer | string | Uint8Array` | Default: `undefined`
-
-Pass a function to transform the files content before beign copied by the plugin. It does not change the source files contents, only the destination ones.
 
 ```js
 copy({

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,12 @@ function stringify(value) {
   return util.inspect(value, { breakLength: Infinity })
 }
 
+async function isFile(filePath) {
+  const fileStats = await fs.stat(filePath)
+
+  return fileStats.isFile()
+}
+
 function renameTarget(target, rename) {
   const parsedPath = path.parse(target)
 
@@ -18,25 +24,22 @@ function renameTarget(target, rename) {
     : rename(parsedPath.name, parsedPath.ext.replace('.', ''))
 }
 
-function generateCopyTarget(src, dest, { flatten, rename, transform }) {
-  const { dir, base } = path.parse(src)
+async function generateCopyTarget(src, dest, { flatten, rename, transform }) {
+  if (transform && !await isFile(src)) {
+    throw new Error(`"transform" option works only on files: '${src}' must be a file`)
+  }
+
+  const { base, dir } = path.parse(src)
   const destinationFolder = (flatten || (!flatten && !dir))
     ? dest
     : dir.replace(dir.split('/')[0], dest)
 
-  let contents = null
-  if (transform) {
-    if (!fs.lstatSync(src).isDirectory()) {
-      contents = transform(fs.readFileSync(src))
-    } else {
-      console.log(yellow(`\`transform\` option only works on files, not on directories (received ${src})`))
-    }
-  }
-
   return {
     src,
     dest: path.join(destinationFolder, rename ? renameTarget(base, rename) : base),
-    contents
+    ...(transform && { contents: await transform(await fs.readFile(src)) }),
+    renamed: rename,
+    transformed: transform
   }
 }
 
@@ -67,7 +70,7 @@ export default function copy(options = {}) {
             throw new Error(`${stringify(target)} target must be an object`)
           }
 
-          const { src, dest, rename, transform, ...restTargetOptions } = target
+          const { dest, rename, src, transform, ...restTargetOptions } = target
 
           if (!src || !dest) {
             throw new Error(`${stringify(target)} target must have "src" and "dest" properties`)
@@ -85,17 +88,17 @@ export default function copy(options = {}) {
           })
 
           if (matchedPaths.length) {
-            matchedPaths.forEach((matchedPath) => {
+            for (const matchedPath of matchedPaths) {
               const generatedCopyTargets = Array.isArray(dest)
-                ? dest.map((destination) => generateCopyTarget(
+                ? await Promise.all(dest.map((destination) => generateCopyTarget(
                   matchedPath,
                   destination,
                   { flatten, rename, transform }
-                ))
-                : [generateCopyTarget(matchedPath, dest, { flatten, rename, transform })]
+                )))
+                : [await generateCopyTarget(matchedPath, dest, { flatten, rename, transform })]
 
               copyTargets.push(...generatedCopyTargets)
-            })
+            }
           }
         }
       }
@@ -105,15 +108,26 @@ export default function copy(options = {}) {
           console.log(green('copied:'))
         }
 
-        for (const { src, dest, contents } of copyTargets) {
-          if (contents) {
+        for (const copyTarget of copyTargets) {
+          const { contents, dest, src, transformed } = copyTarget
+
+          if (transformed) {
             await fs.outputFile(dest, contents, restPluginOptions)
           } else {
             await fs.copy(src, dest, restPluginOptions)
           }
 
           if (verbose) {
-            console.log(green(`  ${bold(src)} → ${bold(dest)}${contents ? ' (transformed)' : ''}`))
+            let message = green(`  ${bold(src)} → ${bold(dest)}`)
+            const flags = Object.entries(copyTarget)
+              .filter(([key, value]) => ['renamed', 'transformed'].includes(key) && value)
+              .map(([key]) => key.charAt(0).toUpperCase())
+
+            if (flags.length) {
+              message = `${message} ${yellow(`[${flags.join(', ')}]`)}`
+            }
+
+            console.log(message)
           }
         }
       } else if (verbose) {

--- a/tests/fixtures/src/assets/asset-transform.css
+++ b/tests/fixtures/src/assets/asset-transform.css
@@ -1,0 +1,3 @@
+.asset-transform {
+  background-color: __to_be_transformed__;
+}

--- a/tests/fixtures/src/assets/asset-transform.css
+++ b/tests/fixtures/src/assets/asset-transform.css
@@ -1,3 +1,0 @@
-.asset-transform {
-  background-color: __to_be_transformed__;
-}

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -277,6 +277,45 @@ describe('Options', () => {
     expect(console.log).toHaveBeenCalledTimes(1)
     expect(console.log).toHaveBeenCalledWith(yellow('no items to copy'))
   })
+
+  test('Verbose with transform', async () => {
+    console.log = jest.fn()
+
+    await build({
+      targets: [{
+        src: ['src/assets/asset-transform.css'],
+        dest: 'dist/css',
+        transform: (c) => c.toString().replace('__to_be_transformed__', 'blue')
+      }],
+      verbose: true
+    })
+
+    expect(console.log).toHaveBeenCalledTimes(2)
+    expect(console.log).toHaveBeenCalledWith(green('copied:'))
+    expect(console.log).toHaveBeenCalledWith(
+      green(`  ${bold('src/assets/asset-transform.css')} → ${bold('dist/css/asset-transform.css')} (transformed)`)
+    )
+  })
+
+  test('Verbose with transform on directory', async () => {
+    console.log = jest.fn()
+
+    await build({
+      targets: [{
+        src: ['src/assets'],
+        dest: 'dist/css',
+        transform: (c) => c.toString().replace('__to_be_transformed__', 'blue')
+      }],
+      verbose: true
+    })
+
+    expect(console.log).toHaveBeenCalledTimes(3)
+    expect(console.log).toHaveBeenCalledWith(yellow('`transform` option only works on files, not on directories (received src/assets)'))
+    expect(console.log).toHaveBeenCalledWith(green('copied:'))
+    expect(console.log).toHaveBeenCalledWith(
+      green(`  ${bold('src/assets')} → ${bold('dist/css/assets')}`)
+    )
+  })
   /* eslint-enable no-console */
 
   test('Hook', async () => {
@@ -292,6 +331,21 @@ describe('Options', () => {
     expect(await fs.pathExists('dist/css')).toBe(true)
     expect(await fs.pathExists('dist/css/css-1.css')).toBe(true)
     expect(await fs.pathExists('dist/css/css-2.css')).toBe(true)
+  })
+
+  test('Transform', async () => {
+    await build({
+      targets: [{
+        src: ['src/assets/asset-transform.css'],
+        dest: 'dist/css',
+        transform: (c) => c.toString().replace('__to_be_transformed__', 'blue')
+      }]
+    })
+
+    expect(await fs.pathExists('dist/css/asset-transform.css')).toBe(true)
+    expect(await fs.readFile('dist/css/asset-transform.css', 'utf-8')).not.toEqual(
+      expect.stringMatching('__to_be_transformed__')
+    )
   })
 
   test('Copy once', async () => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,28 +1,34 @@
 import { rollup, watch } from 'rollup'
 import fs from 'fs-extra'
 import replace from 'replace-in-file'
-import { bold, yellow, green } from 'colorette'
+import { bold, green, yellow, options } from 'colorette'
 import copy from '../src'
 
 process.chdir(`${__dirname}/fixtures`)
 
+options.enabled = true
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function readFile(path) {
+  return fs.readFile(path, 'utf-8')
+}
+
+async function build(pluginOptions) {
+  await rollup({
+    input: 'src/index.js',
+    plugins: [
+      copy(pluginOptions)
+    ]
+  })
 }
 
 afterEach(async () => {
   await fs.remove('build')
   await fs.remove('dist')
 })
-
-async function build(options) {
-  await rollup({
-    input: 'src/index.js',
-    plugins: [
-      copy(options)
-    ]
-  })
-}
 
 describe('Copy', () => {
   test('No config passed', async () => {
@@ -228,11 +234,46 @@ describe('Copy', () => {
     expect(await fs.pathExists('dist/scss-multiple/nested-renamed')).toBe(true)
     expect(await fs.pathExists('dist/scss-multiple/nested-renamed/scss-3.scss')).toBe(true)
   })
+
+  test('Throw if transform target is not a file', async () => {
+    await expect(build({
+      targets: [{
+        src: 'src/assets/css',
+        dest: 'dist',
+        transform: (contents) => contents.toString().replace('blue', 'red')
+      }]
+    })).rejects.toThrow('"transform" option works only on files: \'src/assets/css\' must be a file')
+  })
+
+  test('Transform target', async () => {
+    await build({
+      targets: [{
+        src: 'src/assets/css/css-1.css',
+        dest: ['dist', 'build'],
+        transform: (contents) => contents.toString().replace('blue', 'red')
+      }, {
+        src: 'src/assets/scss/**/*.scss',
+        dest: 'dist',
+        transform: (contents) => contents.toString().replace('background-color', 'color')
+      }]
+    })
+
+    expect(await fs.pathExists('dist/css-1.css')).toBe(true)
+    expect(await readFile('dist/css-1.css')).toEqual(expect.stringContaining('red'))
+    expect(await fs.pathExists('build/css-1.css')).toBe(true)
+    expect(await readFile('build/css-1.css')).toEqual(expect.stringContaining('red'))
+    expect(await fs.pathExists('dist/scss-1.scss')).toBe(true)
+    expect(await readFile('dist/scss-1.scss')).toEqual(expect.not.stringContaining('background-color'))
+    expect(await fs.pathExists('dist/scss-2.scss')).toBe(true)
+    expect(await readFile('dist/scss-2.scss')).toEqual(expect.not.stringContaining('background-color'))
+    expect(await fs.pathExists('dist/scss-3.scss')).toBe(true)
+    expect(await readFile('dist/scss-3.scss')).toEqual(expect.not.stringContaining('background-color'))
+  })
 })
 
 describe('Options', () => {
   /* eslint-disable no-console */
-  test('Verbose', async () => {
+  test('Verbose, copy files', async () => {
     console.log = jest.fn()
 
     await build({
@@ -250,21 +291,13 @@ describe('Options', () => {
 
     expect(console.log).toHaveBeenCalledTimes(5)
     expect(console.log).toHaveBeenCalledWith(green('copied:'))
-    expect(console.log).toHaveBeenCalledWith(
-      green(`  ${bold('src/assets/asset-1.js')} → ${bold('dist/asset-1.js')}`)
-    )
-    expect(console.log).toHaveBeenCalledWith(
-      green(`  ${bold('src/assets/css/css-1.css')} → ${bold('dist/css-1.css')}`)
-    )
-    expect(console.log).toHaveBeenCalledWith(
-      green(`  ${bold('src/assets/css/css-2.css')} → ${bold('dist/css-2.css')}`)
-    )
-    expect(console.log).toHaveBeenCalledWith(
-      green(`  ${bold('src/assets/scss')} → ${bold('dist/scss')}`)
-    )
+    expect(console.log).toHaveBeenCalledWith(green(`  ${bold('src/assets/asset-1.js')} → ${bold('dist/asset-1.js')}`))
+    expect(console.log).toHaveBeenCalledWith(green(`  ${bold('src/assets/css/css-1.css')} → ${bold('dist/css-1.css')}`))
+    expect(console.log).toHaveBeenCalledWith(green(`  ${bold('src/assets/css/css-2.css')} → ${bold('dist/css-2.css')}`))
+    expect(console.log).toHaveBeenCalledWith(green(`  ${bold('src/assets/scss')} → ${bold('dist/scss')}`))
   })
 
-  test('Verbose, no items to copy', async () => {
+  test('Verbose, no files to copy', async () => {
     console.log = jest.fn()
 
     await build({
@@ -278,43 +311,49 @@ describe('Options', () => {
     expect(console.log).toHaveBeenCalledWith(yellow('no items to copy'))
   })
 
-  test('Verbose with transform', async () => {
+  test('Verbose, rename files', async () => {
     console.log = jest.fn()
 
     await build({
-      targets: [{
-        src: ['src/assets/asset-transform.css'],
-        dest: 'dist/css',
-        transform: (c) => c.toString().replace('__to_be_transformed__', 'blue')
-      }],
+      targets: [
+        { src: 'src/assets/asset-1.js', dest: 'dist', rename: 'asset-1-renamed.js' },
+        {
+          src: 'src/assets/scss/*',
+          dest: 'dist/scss-multiple',
+          rename: (name, extension) => (
+            extension
+              ? `${name}-renamed.${extension}`
+              : `${name}-renamed`
+          )
+        }
+      ],
       verbose: true
     })
 
-    expect(console.log).toHaveBeenCalledTimes(2)
+    expect(console.log).toHaveBeenCalledTimes(5)
     expect(console.log).toHaveBeenCalledWith(green('copied:'))
-    expect(console.log).toHaveBeenCalledWith(
-      green(`  ${bold('src/assets/asset-transform.css')} → ${bold('dist/css/asset-transform.css')} (transformed)`)
-    )
+    expect(console.log).toHaveBeenCalledWith(`${green(`  ${bold('src/assets/asset-1.js')} → ${bold('dist/asset-1-renamed.js')}`)} ${yellow('[R]')}`)
+    expect(console.log).toHaveBeenCalledWith(`${green(`  ${bold('src/assets/scss/scss-1.scss')} → ${bold('dist/scss-multiple/scss-1-renamed.scss')}`)} ${yellow('[R]')}`)
+    expect(console.log).toHaveBeenCalledWith(`${green(`  ${bold('src/assets/scss/scss-2.scss')} → ${bold('dist/scss-multiple/scss-2-renamed.scss')}`)} ${yellow('[R]')}`)
+    expect(console.log).toHaveBeenCalledWith(`${green(`  ${bold('src/assets/scss/nested')} → ${bold('dist/scss-multiple/nested-renamed')}`)} ${yellow('[R]')}`)
   })
 
-  test('Verbose with transform on directory', async () => {
+  test('Verbose, transform files', async () => {
     console.log = jest.fn()
 
     await build({
       targets: [{
-        src: ['src/assets'],
-        dest: 'dist/css',
-        transform: (c) => c.toString().replace('__to_be_transformed__', 'blue')
+        src: 'src/assets/css/css-*.css',
+        dest: 'dist',
+        transform: (contents) => contents.toString().replace('background-color', 'color')
       }],
       verbose: true
     })
 
     expect(console.log).toHaveBeenCalledTimes(3)
-    expect(console.log).toHaveBeenCalledWith(yellow('`transform` option only works on files, not on directories (received src/assets)'))
     expect(console.log).toHaveBeenCalledWith(green('copied:'))
-    expect(console.log).toHaveBeenCalledWith(
-      green(`  ${bold('src/assets')} → ${bold('dist/css/assets')}`)
-    )
+    expect(console.log).toHaveBeenCalledWith(`${green(`  ${bold('src/assets/css/css-1.css')} → ${bold('dist/css-1.css')}`)} ${yellow('[T]')}`)
+    expect(console.log).toHaveBeenCalledWith(`${green(`  ${bold('src/assets/css/css-2.css')} → ${bold('dist/css-2.css')}`)} ${yellow('[T]')}`)
   })
   /* eslint-enable no-console */
 
@@ -331,21 +370,6 @@ describe('Options', () => {
     expect(await fs.pathExists('dist/css')).toBe(true)
     expect(await fs.pathExists('dist/css/css-1.css')).toBe(true)
     expect(await fs.pathExists('dist/css/css-2.css')).toBe(true)
-  })
-
-  test('Transform', async () => {
-    await build({
-      targets: [{
-        src: ['src/assets/asset-transform.css'],
-        dest: 'dist/css',
-        transform: (c) => c.toString().replace('__to_be_transformed__', 'blue')
-      }]
-    })
-
-    expect(await fs.pathExists('dist/css/asset-transform.css')).toBe(true)
-    expect(await fs.readFile('dist/css/asset-transform.css', 'utf-8')).not.toEqual(
-      expect.stringMatching('__to_be_transformed__')
-    )
   })
 
   test('Copy once', async () => {


### PR DESCRIPTION
Add the `transform` option allowing to transform the file content (buffer) before being copied (behave similarly to [`webpack-copy-plugin`](https://github.com/webpack-contrib/copy-webpack-plugin#transform)). Also, it warns if the function is run on a directory.

- [x] Tests
- [x] Linting
- [x] Documentation

Fix #21 ?