### PR TITLE
provide 'src' to rename()

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,7 +130,7 @@ copy({
   targets: [{
     src: 'assets/docs/*',
     dest: 'dist/public/docs',
-    rename: (name, extension) => `${name}-v1.${extension}`
+    rename: (name, extension, src) => `${name}-v1.${extension}`
   }]
 })
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -16,12 +16,12 @@ async function isFile(filePath) {
   return fileStats.isFile()
 }
 
-function renameTarget(target, rename) {
+function renameTarget(target, rename, src) {
   const parsedPath = path.parse(target)
 
   return typeof rename === 'string'
     ? rename
-    : rename(parsedPath.name, parsedPath.ext.replace('.', ''))
+    : rename(parsedPath.name, parsedPath.ext.replace('.', ''), src)
 }
 
 async function generateCopyTarget(src, dest, { flatten, rename, transform }) {
@@ -36,7 +36,7 @@ async function generateCopyTarget(src, dest, { flatten, rename, transform }) {
 
   return {
     src,
-    dest: path.join(destinationFolder, rename ? renameTarget(base, rename) : base),
+    dest: path.join(destinationFolder, rename ? renameTarget(base, rename, src) : base),
     ...(transform && { contents: await transform(await fs.readFile(src)) }),
     renamed: rename,
     transformed: transform

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -213,6 +213,14 @@ describe('Copy', () => {
               ? `${name}-renamed.${extension}`
               : `${name}-renamed`
           )
+        },
+        {
+          src: 'src/assets/asset-1.js',
+          dest: 'dist',
+          rename: (name, extension, src) => {
+            expect(src).toBe('src/assets/asset-1.js')
+            return `${name}.${extension}`
+          }
         }
       ]
     })


### PR DESCRIPTION
This provides the full `src` to the file to the rename function.

This is useful for us because we want to append a hash of the file contents to the file name. To do this we need the full path to the file.