### PR TITLE
Provide full src path to transform

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ async function generateCopyTarget(src, dest, { flatten, rename, transform }) {
   return {
     src,
     dest: path.join(destinationFolder, rename ? renameTarget(base, rename, src) : base),
-    ...(transform && { contents: await transform(await fs.readFile(src), base) }),
+    ...(transform && { contents: await transform(await fs.readFile(src), src) }),
     renamed: rename,
     transformed: transform
   }


### PR DESCRIPTION
Instead of passing in just the basename of the source file, pass in the full src path.
This is useful when needing to rewrite contents that contain relative references to other files.