### PR TITLE
Fix missing directory errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 node_modules
 coverage
 dist
+.idea
+.DS_Store
+.vscode
+yarn-debug.log*
+yarn-error.log*

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,10 @@ export default {
 }
 ```
 
+**Note**: if you're using any kind of clean/delete plugins, such as [rollup-plugin-del](https://www.npmjs.com/package/rollup-plugin-del), 
+which remove any of the destination folders, ensure that this plugin is run **after** that plugin, otherwise the copied files might
+accidentally be deleted.
+
 ### Configuration
 
 There are some useful options:

--- a/src/index.js
+++ b/src/index.js
@@ -112,8 +112,16 @@ export default function copy(options = {}) {
           const { contents, dest, src, transformed } = copyTarget
 
           if (transformed) {
+            if (!fs.existsSync(path.dirname(dest))) {
+              fs.mkdirSync(path.dirname(dest), { recursive: true })
+            }
+
             await fs.outputFile(dest, contents, restPluginOptions)
           } else {
+            if (!fs.existsSync(path.dirname(dest))) {
+              fs.mkdirSync(path.dirname(dest), { recursive: true })
+            }
+
             await fs.copy(src, dest, restPluginOptions)
           }
 


### PR DESCRIPTION
fixes: #61

This should fix the occasional `ENOENT` errors. I've also added a disclaimer to the Readme to mention that you need to be careful when using this with plugins that delete the destination folder. 