### PR TITLE
Update default values in types (globby, fast-glob)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,29 +23,29 @@ interface Target extends globby.GlobbyOptions {
      */
     readonly transform?: (contents: Buffer, name: string) => any;
 
-	/**
-	If set to `true`, `globby` will automatically glob directories for you. If you define an `Array` it will only glob files that matches the patterns inside the `Array`. You can also define an `Object` with `files` and `extensions` like in the example below.
+    /**
+    If set to `true`, `globby` will automatically glob directories for you. If you define an `Array` it will only glob files that matches the patterns inside the `Array`. You can also define an `Object` with `files` and `extensions` like in the example below.
 
-	Note that if you set this option to `false`, you won't get back matched directories unless you set `onlyFiles: false`.
+    Note that if you set this option to `false`, you won't get back matched directories unless you set `onlyFiles: false`.
 
-	@default false
+    @default false
 
-	@example
-	```
-	import {globby} from 'globby';
+    @example
+    ```
+    import {globby} from 'globby';
 
-	const paths = await globby('images', {
-		expandDirectories: {
-			files: ['cat', 'unicorn', '*.jpg'],
-			extensions: ['png']
-		}
-	});
+    const paths = await globby('images', {
+        expandDirectories: {
+            files: ['cat', 'unicorn', '*.jpg'],
+            extensions: ['png']
+        }
+    });
 
-	console.log(paths);
-	//=> ['cat.png', 'unicorn.png', 'cow.jpg', 'rainbow.jpg']
-	```
-	*/
-	readonly expandDirectories?: globby.ExpandDirectoriesOption;
+    console.log(paths);
+    //=> ['cat.png', 'unicorn.png', 'cow.jpg', 'rainbow.jpg']
+    ```
+    */
+    readonly expandDirectories?: globby.ExpandDirectoriesOption;
 
     /**
      * Return only files
@@ -53,7 +53,6 @@ interface Target extends globby.GlobbyOptions {
      * @default false
      */
     readonly onlyFiles?: boolean;
-
 }
 
 interface CopyOptions extends globby.GlobbyOptions, fs.WriteFileOptions, fs.CopyOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,38 @@ interface Target extends globby.GlobbyOptions {
      * Modify file contents.
      */
     readonly transform?: (contents: Buffer, name: string) => any;
+
+	/**
+	If set to `true`, `globby` will automatically glob directories for you. If you define an `Array` it will only glob files that matches the patterns inside the `Array`. You can also define an `Object` with `files` and `extensions` like in the example below.
+
+	Note that if you set this option to `false`, you won't get back matched directories unless you set `onlyFiles: false`.
+
+	@default false
+
+	@example
+	```
+	import {globby} from 'globby';
+
+	const paths = await globby('images', {
+		expandDirectories: {
+			files: ['cat', 'unicorn', '*.jpg'],
+			extensions: ['png']
+		}
+	});
+
+	console.log(paths);
+	//=> ['cat.png', 'unicorn.png', 'cow.jpg', 'rainbow.jpg']
+	```
+	*/
+	readonly expandDirectories?: globby.ExpandDirectoriesOption;
+
+    /**
+     * Return only files
+     *
+     * @default false
+     */
+    readonly onlyFiles?: boolean;
+
 }
 
 interface CopyOptions extends globby.GlobbyOptions, fs.WriteFileOptions, fs.CopyOptions {


### PR DESCRIPTION
Issue:
We are setting both `onlyFiles` and `exxpandDirectories` options to `false` [here](https://github.com/vladshcherbin/rollup-plugin-copy/blob/master/src/index.js#L85-L86) as they are set to `true` by default in globby and fast-glob.

In VSCode the autocomplete currently shows with `@default: true` text so I really assumed that it is really set to true before looking at source code.
![Screenshot 2023-09-19 at 15 00 13](https://github.com/vladshcherbin/rollup-plugin-copy/assets/34352395/f3aa598e-5ee3-4f42-98b3-5067c32ec8f1)

This PR changes the `@default`  flag to `false` so it's inline with this rollup-plugin-copy options.
![Screenshot 2023-09-19 at 15 05 44](https://github.com/vladshcherbin/rollup-plugin-copy/assets/34352395/650f093d-5d85-4723-ad42-d61d455021c7)


Not sure if there is a better way of changing intellisense `@default` from 'true' to 'false'. I've copied the type declaraitions from both globby and fast-glob and just changed the default values.
