### PR TITLE
Fix "incorrect default export" type issue

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,4 +65,6 @@ interface CopyOptions extends globby.GlobbyOptions, fs.WriteFileOptions, fs.Copy
 /**
  * Copy files and folders using Rollup
  */
-export default function copy(options?: CopyOptions): rollup.Plugin;
+declare function copy(options?: CopyOptions): rollup.Plugin;
+
+export = copy;


### PR DESCRIPTION
See https://arethetypeswrong.github.io/?p=rollup-plugin-copy%403.5.0. Without this fix, ESM projects using Node16 moduleResolution get a "This expression is not callable" TS error when using this plugin.

Also see https://github.com/eight04/rollup-plugin-external-globals/pull/36 for the same fix done on a different rollup plugin.