### PR TITLE
Add watch mode support for target files

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,12 @@ interface CopyOptions extends globby.GlobbyOptions, fs.WriteFileOptions, fs.Copy
      * @default false
      */
     readonly verbose?: boolean;
+
+    /**
+     * Watch targets for changes.
+     * @default false
+     */
+    readonly watchTargets?: boolean;
 }
 
 /**

--- a/readme.md
+++ b/readme.md
@@ -212,6 +212,19 @@ copy({
 })
 ```
 
+#### watchTargets
+
+Type: `boolean` | Default: `false`
+
+Add the files specified in `targets` to the watch list
+
+```js
+copy({
+  targets: [{ src: "assets/**/*", dest: "dist/public" }],
+  watchTargets: true,
+})
+```
+
 All other options are passed to packages, used inside:
   - [globby](https://github.com/sindresorhus/globby)
   - [fs-extra copy function](https://github.com/jprichardson/node-fs-extra/blob/7.0.0/docs/copy.md)


### PR DESCRIPTION
# Add watch mode support for target files

## What does this PR do?

The following changes have been made:

- Added a feature to watch for changes in files specified in `targets`' `src` during watch mode.
- Only changes in input and `targets`' `src` are detected. In other words, `targets`' `dest` is not monitored.
- This feature is OFF by default to maintain compatibility with the current behavior.
- Adds relevant tests to ensure the new feature works as expected.

## Motivation

Because I want rollup to automatically rerun when assets other than JavaScript are changed during web application development.

## Describe how you validated your changes

I have confirmed that all existing tests pass and added new tests. Additionally, I created a repository for testing, which can be found [here](https://github.com/uraitakahito/hello-my-rollup-plugin-copy).

## Possible Drawbacks / Trade-offs

The current implementation re-copies all `targets` instead of just the modified file, which is inefficient. Users should be aware of this limitation. I hope to address this in a separate pull request if possible.

## Additional Notes

- `addWatchFile` is prohibited from being called in the `buildEnd` event. Therefore, the registration of watch targets is fixed to the `buildStart` event.
- A temporary package with the new feature is available [here](https://www.npmjs.com/package/@uraitakahito/rollup-plugin-copy).
